### PR TITLE
Dependencies update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `lombok-1.18.24`
   - `hibernate-jpamodelgen-6.0.0.Final`
 - Added `jakarta.xml.bind-api` library to prevent `java.lang.NoClassDefFoundError: jakarta/xml/bind/JAXBException: jakarta.xml.bind.JAXBException` 
+- OpenAPI docs link updated in the `README.md` file
 
 ## [1.4.7] - 23-05-2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.8] - 19-04-2022
+
+### Changed
+- Updated the following libraries
+  - `modelmapper-3.1.0`
+  - `lombok-1.18.24`
+  - `hibernate-jpamodelgen-6.0.0.Final`
+- Added `jakarta.xml.bind-api` library to prevent `java.lang.NoClassDefFoundError: jakarta/xml/bind/JAXBException: jakarta.xml.bind.JAXBException` 
+
 ## [1.4.7] - 23-05-2021
+
+### Changed
 - Dummy PR to solve GitHub Packages problem
 
 ## [1.4.7] - 16-02-2021
+
+### Changed
 - Updated the following dependencies
   - `modelmapper-2.4.3`
   - `lombok-1.18.20`
   - `hibernate-jpamodelgen-6.0.0.Alpha8`
   - `spring-boot-starter-parent-2.5.0`
-
-### Changed
 - Added missing `insurance` field in the simulation update
 
 ## [1.4.6] - 14-02-2021

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments=--server.port=<NEW_PORT>
 ```
 
 ## How to access the documentation (Swagger)
-After the application has started open the link: http://localhost:8088/swagger-ui.html
+After the application has started open the link: http://localhost:8088/swagger-ui/index.html
 
 ## How to access the production endpoint
 It's not really a production environment, but the API is also deployed on Heroku.

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,10 @@
     <properties>
         <java.version>11</java.version>
         <springfox.version>3.0.0</springfox.version>
-        <modelmapper.version>2.4.3</modelmapper.version>
-        <lombok.version>1.18.20</lombok.version>
-        <hibernate-jpamodelgen.version>6.0.0.Alpha8</hibernate-jpamodelgen.version>
+        <modelmapper.version>3.1.0</modelmapper.version>
+        <lombok.version>1.18.24</lombok.version>
+        <hibernate-jpamodelgen.version>6.0.0.Final</hibernate-jpamodelgen.version>
+        <jakarta.xml.bind.version>3.0.1</jakarta.xml.bind.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven-failsafe.version>3.0.0-M5</maven-failsafe.version>
 
@@ -95,6 +96,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
             <version>${hibernate-jpamodelgen.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### Changed
- Updated the following libraries
  - `modelmapper-3.1.0`
  - `lombok-1.18.24`
  - `hibernate-jpamodelgen-6.0.0.Final`
- Added `jakarta.xml.bind-api` library to prevent `java.lang.NoClassDefFoundError: jakarta/xml/bind/JAXBException: jakarta.xml.bind.JAXBException` 
- OpenAPI docs link updated in the `README.md` file