### PR TITLE
Fix database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 20-12-2022
+
+### Changed
+- Removal of database `derby`, replaced by `h2`
+- Removal of `springdoc-openapi-ui`, replaced by `springdoc-openapi-starter-webmvc-ui`
+- Added `spring.datasource` for `h2` at `application.properties`
+- Changed the default OpenAPI URL in the `application.properties`
+- Adoption of new packages for the OpenAPI in the `OpenApiConfig`
+
 ## [1.7.0] - 19-12-2022
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments=--server.port=<NEW_PORT>
 ```
 
 ## How to access the documentation (Swagger)
-After the application has started open the link: http://localhost:8088/swagger-ui/index.html
+After the application has started open the link: http://localhost:8088/swagger-ui.html
 
 ## How to access the production endpoint
 It's not really a production environment, but the API is also deployed on Heroku.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.eliasogueira.credit</groupId>
     <artifactId>combined-credit-api</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.1-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>
@@ -28,12 +28,13 @@
         <maven-failsafe.version>3.0.0-M7</maven-failsafe.version>
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 
-        <springdoc-openapi-ui.version>1.6.14</springdoc-openapi-ui.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
         <modelmapper.version>3.1.1</modelmapper.version>
         <lombok.version>1.18.24</lombok.version>
         <hibernate-jpamodelgen.version>6.1.6.Final</hibernate-jpamodelgen.version>
         <jakarta-xml-bind-api.version>4.0.0</jakarta-xml-bind-api.version>
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
+        <h2.version>2.1.214</h2.version>
 
         <!-- security library updates -->
         <commons-codec.version>1.15</commons-codec.version>
@@ -85,15 +86,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>${springdoc-openapi-ui.version}</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/eliasnogueira/credit/openapi/OpenApiConfig.java
+++ b/src/main/java/com/eliasnogueira/credit/openapi/OpenApiConfig.java
@@ -24,8 +24,8 @@
 
 package com.eliasnogueira.credit.openapi;
 
-import org.springdoc.core.SpringDocConfigProperties;
-import org.springdoc.core.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,12 @@ spring.profiles.active=default
 
 spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.DerbyDialect
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.datasource.url=jdbc:h2:mem:credit
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
 
 management.endpoint.health.show-details=always
 
@@ -14,3 +19,4 @@ logging.level.com.eliasnogueira.credit=INFO
 
 springdoc.api-docs.enabled=false
 springdoc.swagger-ui.url=/credit-api.yaml
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
### Changed
- Removal of database `derby`, replaced by `h2`
- Removal of `springdoc-openapi-ui`, replaced by `springdoc-openapi-starter-webmvc-ui`
- Added `spring.datasource` for `h2` at `application.properties`
- Changed the default OpenAPI URL in the `application.properties`
- Adoption of new packages for the OpenAPI in the `OpenApiConfig`