### PR TITLE
libraries update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.6] - 04-05-2023
+
+### Changed
+- Updated the following libraries
+  - `spring-boot-starter-parent -> 3.0.6`
+  - `springdoc-openapi-starter-webmvc-ui.version -> 2.1.0`
+  - `lombok.version -> 1.18.26`
+  - `hibernate-jpamodelgen.version -> 6.2.2.Final`
+  - `jackson-databind.version -> 2.15.0`
+
 ## [1.8.5] - 23-01-2023
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.6</version>
     </parent>
 
     <groupId>com.eliasogueira.credit</groupId>
     <artifactId>combined-credit-api</artifactId>
-    <version>1.8.5-SNAPSHOT</version>
+    <version>1.8.6-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>
@@ -28,10 +28,10 @@
         <maven-failsafe.version>3.0.0-M7</maven-failsafe.version>
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 
-        <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <modelmapper.version>3.1.1</modelmapper.version>
-        <lombok.version>1.18.24</lombok.version>
-        <hibernate-jpamodelgen.version>6.1.6.Final</hibernate-jpamodelgen.version>
+        <lombok.version>1.18.26</lombok.version>
+        <hibernate-jpamodelgen.version>6.2.2.Final</hibernate-jpamodelgen.version>
         <jakarta-xml-bind-api.version>4.0.0</jakarta-xml-bind-api.version>
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
         <h2.version>2.1.214</h2.version>
@@ -39,7 +39,7 @@
 
         <!-- security library updates -->
         <commons-codec.version>1.15</commons-codec.version>
-        <jackson-databind.version>2.14.1</jackson-databind.version>
+        <jackson-databind.version>2.15.0</jackson-databind.version>
         <guava.version>31.1-jre</guava.version>
         <jcommander.version>1.82</jcommander.version>
 


### PR DESCRIPTION
### Changed
- Updated the following libraries
  - `spring-boot-starter-parent -> 3.0.6`
  - `springdoc-openapi-starter-webmvc-ui.version -> 2.1.0`
  - `lombok.version -> 1.18.26`
  - `hibernate-jpamodelgen.version -> 6.2.2.Final`
  - `jackson-databind.version -> 2.15.0`