### PR TITLE
chore: latest updates

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 22
+      - name: Set up JDK 23
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 22
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 22
+      - name: Set up JDK 23
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 22
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.9] - 12-10-2024
+
+## Changed
+
+- Project and GitHub workflow updated to Java 23
+- Added ` <maven.compiler.proc>full</maven.compiler.proc>` to solve the JDK 23 + Lombok issues
+- Updated Maven Wrapper
+- Updated the following libraries
+  - `spring-boot-starter-parent -> 3.3.4`
+  - `maven-surefire-plugin -> 3.5.1`
+  - `modelmapper -> 3.2.1`
+  - `hibernate-jpamodelgen -> 6.6.1.Final`
+  - `h2 -> 2.3.232`
+  - `junit -> 5.11.2`
+  - `datafaker -> 2.4.0`
+  - `testcontainers -> 1.20.2`
+  - `commons-compress -> 1.27.1`
+
 ## [1.3.8] - 08-08-2024
 
 ### Changed
+
 - Updated the following libraries
     - `junit -> 5.10.3`
 - Added the `maven-surefire-junit5-tree-reporter` plugin to the `maven-surefire-plugin` execution
@@ -38,20 +57,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Maven Wrapper
 - Bump actions/cache
 - Updated the following libraries
-  - `spring-boot-starter-parent -> 3.3.0`
-  - `hibernate-jpamodelgen.version -> 6.5.2.Final`
-  - `junit.version -> 5.11.0-M2`
-  - `assertj.version -> 3.26.0`
-  - `datafaker.version -> 2.2.2`
-  - `testcontainers.version -> 1.19.8`
+    - `spring-boot-starter-parent -> 3.3.0`
+    - `hibernate-jpamodelgen.version -> 6.5.2.Final`
+    - `junit.version -> 5.11.0-M2`
+    - `assertj.version -> 3.26.0`
+    - `datafaker.version -> 2.2.2`
+    - `testcontainers.version -> 1.19.8`
 
 ## [1.13.5] - 10-0442024
 
 ### Changed
 
 - Updated the following libraries
-  - `springdoc-openapi-starter-webmvc-ui -> 2.5.0`
-  - `jib-maven-plugin -> 3.4.2`
+    - `springdoc-openapi-starter-webmvc-ui -> 2.5.0`
+    - `jib-maven-plugin -> 3.4.2`
 
 ## [1.13.2 - 1.13.4] - 01-04-2024
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.4</version>
     </parent>
 
     <groupId>com.eliasogueira.credit</groupId>
     <artifactId>combined-credit-api</artifactId>
-    <version>1.13.8</version>
+    <version>1.13.9</version>
 
     <distributionManagement>
         <repository>
@@ -25,25 +25,26 @@
     <properties>
         <java.version>22</java.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven.compiler.proc>full</maven.compiler.proc>
+        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
         <maven-surefire-junit5-tree-reporter.version>1.3.0</maven-surefire-junit5-tree-reporter.version>
 
         <springdoc-openapi-starter-webmvc-ui.version>2.6.0</springdoc-openapi-starter-webmvc-ui.version>
-        <modelmapper.version>3.2.0</modelmapper.version>
+        <modelmapper.version>3.2.1</modelmapper.version>
         <lombok.version>1.18.34</lombok.version>
-        <hibernate-jpamodelgen.version>6.5.2.Final</hibernate-jpamodelgen.version>
+        <hibernate-jpamodelgen.version>6.6.1.Final</hibernate-jpamodelgen.version>
         <jakarta-xml-bind-api.version>4.0.2</jakarta-xml-bind-api.version>
-        <h2.version>2.3.230</h2.version>
+        <h2.version>2.3.232</h2.version>
         <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
 
-        <junit.version>5.11.0-M2</junit.version>
+        <junit.version>5.11.2</junit.version>
         <restassured.version>5.5.0</restassured.version>
         <assertj.version>3.26.3</assertj.version>
-        <datafaker.version>2.3.1</datafaker.version>
-        <testcontainers.version>1.20.0</testcontainers.version>
+        <datafaker.version>2.4.0</datafaker.version>
+        <testcontainers.version>1.20.2</testcontainers.version>
 
         <!-- transitive vulnerable dependencies -->
-        <commons-compress>1.26.2</commons-compress>
+        <commons-compress>1.27.1</commons-compress>
 
         <start-class>com.eliasnogueira.credit.CreditApiApplication</start-class>
     </properties>
@@ -108,7 +109,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
             <version>${hibernate-jpamodelgen.version}</version>
         </dependency>
@@ -130,26 +131,14 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${restassured.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.rest-assured</groupId>
-                    <artifactId>xml-path</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.rest-assured</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured-all</artifactId>
             <version>${restassured.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -170,10 +159,15 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Changed

- Project and GitHub workflow updated to Java 23
- Added ` <maven.compiler.proc>full</maven.compiler.proc>` to solve the JDK 23 + Lombok issues
- Updated Maven Wrapper
- Updated the following libraries
  - `spring-boot-starter-parent -> 3.3.4`
  - `maven-surefire-plugin -> 3.5.1`
  - `modelmapper -> 3.2.1`
  - `hibernate-jpamodelgen -> 6.6.1.Final`
  - `h2 -> 2.3.232`
  - `junit -> 5.11.2`
  - `datafaker -> 2.4.0`
  - `testcontainers -> 1.20.2`
  - `commons-compress -> 1.27.1`