### PR TITLE
Library updates

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 23
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 23
+          java-version: 25
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 23
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 23
+          java-version: 25
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 05-01-2026
+
+### Changed
+
+- Updated the following libraries
+  - `spring-boot-starter-parent -> 4.0.1`
+  - `java -> 25`
+  - `maven-compiler-plugin -> 3.14.1`
+  - `maven-surefire-plugin -> 3.5.4`
+  - `springdoc-openapi-starter-webmvc-ui -> 3.0.1`
+  - `modelmapper -> 3.2.6`
+  - `lombok -> 1.18.42`
+  - `hibernate-jpamodelgen -> 7.2.0.Final`
+  - `jakarta-xml-bind-api -> 4.0.4`
+  - `h2 -> 2.4.240`
+  - `junit -> 6.0.1`
+  - `restassured -> 6.0.0`
+  - `assertj -> 3.27.6`
+  - `datafaker -> 2.5.3`
+  - `testcontainers -> 2.0.3`
+- Fixed `RestTemplateBuilder` resolution by correcting the Spring Boot parent version
+
+
 ## [1.3.18] - 09-02-2025
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>4.0.1</version>
     </parent>
 
     <groupId>com.eliasogueira.credit</groupId>
     <artifactId>combined-credit-api</artifactId>
-    <version>1.13.18</version>
+    <version>2.0.0</version>
 
     <distributionManagement>
         <repository>
@@ -23,26 +23,26 @@
     </distributionManagement>
 
     <properties>
-        <java.version>23</java.version>
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <java.version>25</java.version>
+        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven.compiler.proc>full</maven.compiler.proc>
-        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-        <maven-surefire-junit5-tree-reporter.version>1.4.0</maven-surefire-junit5-tree-reporter.version>
+        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+        <maven-surefire-junit5-tree-reporter.version>1.5.1</maven-surefire-junit5-tree-reporter.version>
 
-        <springdoc-openapi-starter-webmvc-ui.version>2.8.4</springdoc-openapi-starter-webmvc-ui.version>
-        <modelmapper.version>3.2.2</modelmapper.version>
-        <lombok.version>1.18.36</lombok.version>
-        <hibernate-jpamodelgen.version>6.6.4.Final</hibernate-jpamodelgen.version>
-        <jakarta-xml-bind-api.version>4.0.2</jakarta-xml-bind-api.version>
-        <h2.version>2.3.232</h2.version>
-        <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
-        <jib.image>eclipse-temurin:23-jdk-alpine</jib.image>
+        <springdoc-openapi-starter-webmvc-ui.version>3.0.1</springdoc-openapi-starter-webmvc-ui.version>
+        <modelmapper.version>3.2.6</modelmapper.version>
+        <lombok.version>1.18.42</lombok.version>
+        <hibernate-jpamodelgen.version>7.2.0.Final</hibernate-jpamodelgen.version>
+        <jakarta-xml-bind-api.version>4.0.4</jakarta-xml-bind-api.version>
+        <h2.version>2.4.240</h2.version>
+        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
+        <jib.image>eclipse-temurin:25-jdk-alpine</jib.image>
 
-        <junit.version>5.11.4</junit.version>
-        <restassured.version>5.5.0</restassured.version>
-        <assertj.version>3.27.3</assertj.version>
-        <datafaker.version>2.4.2</datafaker.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
+        <junit.version>6.0.1</junit.version>
+        <restassured.version>6.0.0</restassured.version>
+        <assertj.version>3.27.6</assertj.version>
+        <datafaker.version>2.5.3</datafaker.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
 
         <!-- transitive vulnerable dependencies -->
         <logback-core.version>1.5.15</logback-core.version>
@@ -76,6 +76,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <springdoc-openapi-starter-webmvc-ui.version>3.0.1</springdoc-openapi-starter-webmvc-ui.version>
         <modelmapper.version>3.2.6</modelmapper.version>
         <lombok.version>1.18.42</lombok.version>
-        <hibernate-jpamodelgen.version>7.2.0.Final</hibernate-jpamodelgen.version>
+        <hibernate-processor.version>7.2.0.Final</hibernate-processor.version>
         <jakarta-xml-bind-api.version>4.0.4</jakarta-xml-bind-api.version>
         <h2.version>2.4.240</h2.version>
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
@@ -118,8 +118,8 @@
 
         <dependency>
             <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${hibernate-jpamodelgen.version}</version>
+            <artifactId>hibernate-processor</artifactId>
+            <version>${hibernate-processor.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/eliasnogueira/credit/controller/SimulationsController.java
+++ b/src/main/java/com/eliasnogueira/credit/controller/SimulationsController.java
@@ -33,7 +33,7 @@ import com.eliasnogueira.credit.exception.SimulationException;
 import com.eliasnogueira.credit.repository.SimulationRepository;
 import jakarta.validation.Valid;
 import org.modelmapper.ModelMapper;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;

--- a/src/main/java/com/eliasnogueira/credit/exception/RestTemplateErrorHandler.java
+++ b/src/main/java/com/eliasnogueira/credit/exception/RestTemplateErrorHandler.java
@@ -32,14 +32,9 @@ import java.io.IOException;
 @Component
 public class RestTemplateErrorHandler implements ResponseErrorHandler {
 
-    // ignoring when there's no restrictions 404 is returned
+    // ignoring when there are no restrictions, 404 is returned
     @Override
     public boolean hasError(ClientHttpResponse response) throws IOException {
         return response.getStatusCode().value() != 404;
-    }
-
-    @Override
-    public void handleError(ClientHttpResponse response) {
-        // do nothing
     }
 }

--- a/src/test/java/com/eliasnogueira/credit/data/factory/SimulationDataFactory.java
+++ b/src/test/java/com/eliasnogueira/credit/data/factory/SimulationDataFactory.java
@@ -111,7 +111,7 @@ public final class SimulationDataFactory {
 
     public static Simulation simulationWithNotValidEmail() {
         var simulationWithNotValidEmail = validSimulation();
-        simulationWithNotValidEmail.setEmail(faker.internet().username());
+        simulationWithNotValidEmail.setEmail(faker.credentials().username());
 
         log.info(simulationWithNotValidEmail);
         return simulationWithNotValidEmail;


### PR DESCRIPTION
### Changed

- Updated the following libraries
  - `spring-boot-starter-parent -> 4.0.1`
  - `java -> 25`
  - `maven-compiler-plugin -> 3.14.1`
  - `maven-surefire-plugin -> 3.5.4`
  - `springdoc-openapi-starter-webmvc-ui -> 3.0.1`
  - `modelmapper -> 3.2.6`
  - `lombok -> 1.18.42`
  - `hibernate-jpamodelgen -> 7.2.0.Final`
  - `jakarta-xml-bind-api -> 4.0.4`
  - `h2 -> 2.4.240`
  - `junit -> 6.0.1`
  - `restassured -> 6.0.0`
  - `assertj -> 3.27.6`
  - `datafaker -> 2.5.3`
  - `testcontainers -> 2.0.3`
- Fixed `RestTemplateBuilder` resolution by correcting the Spring Boot parent version
